### PR TITLE
Expose InfiniteZipper type

### DIFF
--- a/src/List/InfiniteZipper.elm
+++ b/src/List/InfiniteZipper.elm
@@ -17,6 +17,7 @@ module List.InfiniteZipper
         , toList
         , append
         , push
+        , InfiniteZipper
         )
 
 {-|


### PR DESCRIPTION
Otherwise it is impossible to use the type from outside the module.